### PR TITLE
Consolidated main.css to reuse landing page layout

### DIFF
--- a/app/css/main.css
+++ b/app/css/main.css
@@ -155,8 +155,8 @@ main {
 }
 
 .hero .wrapper {
-  padding-top: 20vh;
-  padding-bottom: 20vh;
+  padding-top: 21vh;
+  padding-bottom: 24vh;
 }
 
 .hero-title {
@@ -205,6 +205,17 @@ main {
 section .wrapper {
   padding-top: 40px;
   padding-bottom: 40px;
+}
+section .caption {
+  margin-bottom: -8px;
+  max-width: 360px;
+}
+section h2 {
+  margin-top: 0;
+  margin-bottom: 4px;
+}
+section p {
+  padding-right: 20px;
 }
 
 .responsive-row {
@@ -409,6 +420,12 @@ th, td {
   }
 }
 @media screen and (max-width: 640px) {
+
+  h2 {
+    font-size: 24px;
+    line-height: 32px;
+  }
+
   .main-nav {
     height: 56px;
     padding-left: 20px;

--- a/app/index.html
+++ b/app/index.html
@@ -36,22 +36,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       will-change: transform;
       transform: scale(1);
     }
-    h2 {
-      margin-top: 0;
-      margin-bottom: 4px;
-    }
 
-    section .caption {
-      margin-bottom: -8px;
-      max-width: 360px;
-    }
-
-    #section-about p,
-    #section-why p,
-    #section-news p {
-      padding-right: 20px;
-      max-width: 540px;
-    }
     #section-about .responsive-row > *,
     #section-news .responsive-row > * {
       margin-bottom: 40px;
@@ -143,15 +128,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         margin-bottom: 20px;
       }
 
-      section .section-title {
-        font-size: 36px;
-        line-height: 46px;
-      }
-
-      h2 {
-        font-size: 24px;
-        line-height: 32px;
-      }
     }
   </style>
 


### PR DESCRIPTION
After refining pwa starter kit landing page, I realized we can reuse some of the layout & type styling from polymer-project.org. 