### PR TITLE
fix #14

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -93,6 +93,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
     .product-grid-item .status {
       position: absolute;
+      left: 0;
       right: 0;
       top: 0;
       bottom: 0;


### PR DESCRIPTION
Fixes https://github.com/Polymer/polymer-project.org/issues/14
Verified the label is aligned correctly now in all supported browsers.

<img width="1200" alt="screen shot 2018-12-11 at 11 24 53 am" src="https://user-images.githubusercontent.com/116360/49825158-984d5180-fd38-11e8-8098-8da87f5492f0.png">
