### PR TITLE
Replace logo-lockup styling with theme-specfic styling

### DIFF
--- a/app/blog/index.html
+++ b/app/blog/index.html
@@ -18,7 +18,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   <header class="hero">
     <div class="wrapper">
-      <div id="logo-lockup" class="hero-title">Blog</div>
+      <div class="hero-title">Blog</div>
       <p class="hero-caption">The latest goings-on with the Polymer project and in the community.
         We'll update this page to announce major releases and showcase cool stuff
         being built with Polymer. Have an idea for an article?

--- a/app/css/main.css
+++ b/app/css/main.css
@@ -85,26 +85,6 @@ pre {
   box-sizing: border-box;
 }
 
-/* Logo lockup */
-#logo-lockup {
-  white-space: nowrap;
-  margin-bottom: -30px;
-}
-#logo-lockup::before {
-  width: 64px;
-  height: 44px;
-  background-image: url(../images/logos/p-logo.svg);
-  background-size: contain;
-  background-repeat: no-repeat;
-  background-position: 50% 50%;
-  display: inline-block;
-  margin-right: 20px;
-  content: '';
-}
-#logo-lockup::after {
-  display: none;
-}
-
 
 /* blog styling */
 .author-img {
@@ -602,14 +582,6 @@ th, td {
 
   .responsive-row {
     flex-direction: column;
-  }
-  #logo-lockup {
-    margin-bottom: -20px;
-  }
-  #logo-lockup::before {
-    margin-right: 12px;
-    width: 38px;
-    height: 26px;
   }
 
   #section-features h2 {

--- a/app/css/theme.css
+++ b/app/css/theme.css
@@ -14,8 +14,36 @@ a {
   color: #FF4470;
 }
 
+.hero-title {
+  margin-bottom: -30px;
+}
+
+.hero-title::before {
+  width: 64px;
+  height: 44px;
+  background-image: url(../images/logos/p-logo.svg);
+  background-size: contain;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+  display: inline-block;
+  margin-right: 20px;
+  content: '';
+}
+
+@media screen and (max-width: 640px) {
+  .hero-title {
+    margin-bottom: -20px;
+  }
+
+  .hero-title::before {
+    margin-right: 12px;
+    width: 38px;
+    height: 26px;
+  }
+}
+
 .hero-title::after {
-  background: #FF4470;
+  display: none;
 }
 
 .grey-bg {

--- a/app/index.html
+++ b/app/index.html
@@ -17,7 +17,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <header class="hero">
     {% include 'templates/topnav.html' %}
     <div class="wrapper">
-      <div id="logo-lockup" class="hero-title">Polymer Project</div>
+      <div class="hero-title">Polymer Project</div>
       <p class="hero-caption">We work on libraries, tools, and standards to help developers build a better web</p>
       <a class="hero-link link-with-arrow" href="/blog/">Blog</a>
     </div>


### PR DESCRIPTION
This allows the title to wrap on smaller viewports (<=320px) to avoid horizontal page scroll.

Ref #40 