### PR TITLE
Update link to webcomponents.org

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -213,7 +213,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div style="flex: 1">
           <p>If you like, you can build your app entirely out of Web Components. Breaking your app up into right-sized components helps make your code cleaner and less expensive to maintain.</p>
           <p>Products like LitElement and PWA Starter Kit make Web Components easier to use and highlight best practices, helping you get great results.</p>
-          <a class="link-with-arrow" href="https://webcomponents.org">Learn more</a>
+          <a class="link-with-arrow" href="https://www.webcomponents.org">Learn more</a>
         </div>
       </div>
     </div>


### PR DESCRIPTION
https://webcomponents.org has an SSL configuration issue and throws a warning when this link is clicked in Chrome (78.0.3904.97  OSX 10.14.6).

Ideally webcomponents.org should update their SSL, but in the meantime, it might be good to have this link not throw an error.

You can also see the issue with curl:

curl -v https://webcomponents.org
...
* Server certificate:
*  subject: C=US; ST=California; L=Mountain View; O=Google LLC; CN=*.webcomponents.org
*  start date: Jul  2 20:11:27 2019 GMT
*  expire date: Jun 30 20:11:27 2020 GMT
*  subjectAltName does not match webcomponents.org
* SSL: no alternative certificate subject name matches target host name 'webcomponents.org'