### PR TITLE
Update polyfill repo / webcomponents.org URLs

### DIFF
--- a/app/blog/2016-05-19-Polymer-IO-2016.md
+++ b/app/blog/2016-05-19-Polymer-IO-2016.md
@@ -24,7 +24,7 @@ combinations of data and device.
 Fortunately, the web platform is evolving to meet these challenges:
 
 * Thanks to
-[Web Components](http://webcomponents.org/), developers have a way to extend HTML itself:
+[Web Components](https://www.webcomponents.org/), developers have a way to extend HTML itself:
 to unlock the powerful component model that's baked directly into the browser and build an
 application out of granular, low-overhead components.
 

--- a/app/index.html
+++ b/app/index.html
@@ -213,7 +213,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         <div style="flex: 1">
           <p>If you like, you can build your app entirely out of Web Components. Breaking your app up into right-sized components helps make your code cleaner and less expensive to maintain.</p>
           <p>Products like LitElement and PWA Starter Kit make Web Components easier to use and highlight best practices, helping you get great results.</p>
-          <a class="link-with-arrow" href="https://webcomponents.org">Learn more</a>
+          <a class="link-with-arrow" href="https://www.webcomponents.org">Learn more</a>
         </div>
       </div>
     </div>

--- a/app/index.html
+++ b/app/index.html
@@ -152,7 +152,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <p>High-fidelity realizations of Google's Material Design spec that work anywhere on the web.</p>
           <span class="status">Prerelease</span>
         </a>
-        <a class="onload-fadein product-grid-item right" href="https://github.com/WebComponents/webcomponentsjs" style="animation-delay: .25s; background: #00D67C; background: linear-gradient(315deg, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0) 100%), linear-gradient(315deg, #FF4ED4 0%, #FF00C1 100%)">
+        <a class="onload-fadein product-grid-item right" href="https://github.com/webcomponents/polyfills" style="animation-delay: .25s; background: #00D67C; background: linear-gradient(315deg, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0) 100%), linear-gradient(315deg, #FF4ED4 0%, #FF00C1 100%)">
           <div class="thumb" style="background-image:url(/images/thumbnails/thumb_polyfills.svg); padding-top: 35%; margin: 12px 12%;"></div>
           <h2>Web Components Polyfills</h2>
           <p>A suite of polyfills supporting the Web Components specs.</p>

--- a/app/index.html
+++ b/app/index.html
@@ -152,7 +152,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <p>High-fidelity realizations of Google's Material Design spec that work anywhere on the web.</p>
           <span class="status">Prerelease</span>
         </a>
-        <a class="onload-fadein product-grid-item right" href="https://github.com/webcomponents/polyfills" style="animation-delay: .25s; background: #00D67C; background: linear-gradient(315deg, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0) 100%), linear-gradient(315deg, #FF4ED4 0%, #FF00C1 100%)">
+        <a class="onload-fadein product-grid-item right" href="https://github.com/webcomponents/polyfills/tree/master/packages/webcomponentsjs" style="animation-delay: .25s; background: #00D67C; background: linear-gradient(315deg, rgba(255,255,255,0.5) 0%, rgba(255,255,255,0) 100%), linear-gradient(315deg, #FF4ED4 0%, #FF00C1 100%)">
           <div class="thumb" style="background-image:url(/images/thumbnails/thumb_polyfills.svg); padding-top: 35%; margin: 12px 12%;"></div>
           <h2>Web Components Polyfills</h2>
           <p>A suite of polyfills supporting the Web Components specs.</p>


### PR DESCRIPTION
I updated it here to point to the new repo's root. Though, the current link goes to the old repo for webcomponentsjs specifically. Would we want to link to that package's folder directly?