### PR TITLE
Fix copyright dates.

### DIFF
--- a/templates/footer.html
+++ b/templates/footer.html
@@ -8,7 +8,7 @@
         </div>
         <div class="attribution">
           Brought to you by <a href="https://www.polymer-project.org">The Polymer Project</a>.<br>
-          Copyright 2018 The Polymer Project Authors. Code licensed under the
+          Copyright 2015–2020 The Polymer Project Authors. Code licensed under the
           <a target="_blank" href="http://polymer.github.io/LICENSE.txt">BSD License</a>.
           Documentation licensed under CC BY 3.0.
         </div>


### PR DESCRIPTION
#4/4. Static dates here, too, alas. Replaced generic date with dates representing the actual site content--imagine that. 

Staged: https://20200527t142608-dot-polymer-project.appspot.com/